### PR TITLE
MCP: Local high-res badge images in /images/ + multi-badge support

### DIFF
--- a/.github/workflows/update-active-badge.yml
+++ b/.github/workflows/update-active-badge.yml
@@ -1,37 +1,42 @@
-name: Update Active Credly Badge
+name: Update Active Credly Badges
 
 on:
   schedule:
-    - cron: '0 12 * * *'   # Daily at noon
+    - cron: '0 12 * * *'
   workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  update-badge:
+  update-badges:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch Latest Active Badge from Credly
-        id: badge
+      - name: Fetch Active Badges from Credly
+        id: badges
         run: |
-          # Public Credly endpoint for your badges
           curl -s "https://www.credly.com/users/jacob-kraniak/badges.json" > badges.json
-          
-          # Get most recent active badge (adjust logic if needed)
-          LATEST=$(jq -r '.data[0] | select(.badge_template.state == "active") | "\(.badge_template.image_url)|\(.badge_template.name)|\(.badge_template.public_url)"' badges.json)
-          
-          echo "BADGE_DATA=$LATEST" >> $GITHUB_ENV
+          ACTIVE_BADGES=$(jq -r '.data[] | select(.state == "accepted") | "\(.badge_template.image_url)|\(.badge_template.name)|\(.badge_template.public_url // .public_url)"' badges.json | head -n 6 | tr '\n' ';;' | sed 's/;;$//')
+          echo "BADGE_DATA=$ACTIVE_BADGES" >> $GITHUB_ENV
+          echo "Found $(wc -l <<<"$ACTIVE_BADGES" | tr -d ' ') active badges"
 
-      - name: Update Active Badge Section in README
-        run: |
-          python scripts/update_active_badge.py "${BADGE_DATA}"
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
 
-      - name: Commit and push
+      - name: Install deps
+        run: pip install requests
+
+      - name: Update Badges + Download Images
+        run: python scripts/update_active_badge.py "$BADGE_DATA"
+
+      - name: Commit & Push
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "docs: auto-update Active Badge from Credly"
-          file_pattern: README.md
+          commit_message: "docs(mcp): auto-update Active Badges + high-res local /images/"
+          file_pattern: README.md images/*
+          branch: main

--- a/scripts/update_active_badge.py
+++ b/scripts/update_active_badge.py
@@ -1,29 +1,55 @@
 import sys
+import os
+import re
+import requests
+
+def sanitize_filename(name):
+    return re.sub(r'[^a-zA-Z0-9._-]+', '_', name).lower() + '.png'
+
+def download_badge_image(image_url, filename):
+    try:
+        response = requests.get(image_url, timeout=10)
+        if response.status_code == 200:
+            with open(os.path.join('images', filename), 'wb') as f:
+                f.write(response.content)
+            print(f'Downloaded high-res {filename} (better quality)')
+            return f'images/{filename}'
+        else:
+            print(f'Failed to download {image_url}')
+            return image_url
+    except Exception as e:
+        print(f'Error downloading: {e}')
+        return image_url
 
 if len(sys.argv) > 1 and sys.argv[1]:
-    image_url, name, url = sys.argv[1].split('|')
+    badge_str = sys.argv[1]
+    badges = []
+    for item in [x for x in badge_str.split(';;') if x]:
+        parts = [p.strip() for p in item.split('|', 2)]
+        if len(parts) == 3:
+            badges.append(parts)
 else:
-    image_url = "https://raw.githubusercontent.com/jacob-kraniak/jacob-kraniak/main/images/comptia-server-certification.4.png"
-    name = "CompTIA Server+"
-    url = "https://www.credly.com/badges/1fc6fa72-65b5-4d96-bf02-88a27b0e71e2/public_url"
+    badges = [("https://images.credly.com/images/ff6cecf9-8aca-43c5-8070-44023bb55417/blob", "CompTIA Server+", "https://www.credly.com/badges/1fc6fa72-65b5-4d96-bf02-88a27b0e71e2/public_url")]
 
-with open("README.md", "r", encoding="utf-8") as f:
+os.makedirs('images', exist_ok=True)
+
+badge_md = '### Active Badges\n\n<p align="center">\n'
+for image_url, name, url in badges[:6]:
+    filename = sanitize_filename(name)
+    local_path = download_badge_image(image_url, filename)
+    badge_md += f'  <a href="{url}">\n    <img src="{local_path}" alt="{name}" width="180" style="margin: 8px;" />\n  </a>\n'
+badge_md += '</p>\n'
+
+with open('README.md', 'r', encoding='utf-8') as f:
     content = f.read()
 
-# Replace the Active Badge section
-new_badge = f"""### Active Badge
-<p align="center">
-  <a href="{url}">
-    <img src="{image_url}" alt="{name}" width="150" />
-  </a>
-</p>
-"""
-
-start = content.find("### Active Badge")
-end = content.find("### Certification Details", start)
+start = content.find('### Active Badge')
+end = content.find('### Certification Details', start) if start != -1 else -1
 
 if start != -1 and end != -1:
-    new_content = content[:start] + new_badge + content[end:]
-    with open("README.md", "w", encoding="utf-8") as f:
+    new_content = content[:start] + badge_md + content[end:]
+    with open('README.md', 'w', encoding='utf-8') as f:
         f.write(new_content)
-    print(f"✅ Updated Active Badge to: {name}")
+    print(f'✅ Updated {len(badges)} Active Badges (local high-res images)')
+else:
+    print('Section not found')


### PR DESCRIPTION
Automated updates via MCP for Credly active badges:

- Downloads full-res PNGs to /images/ folder for faster loading
- Supports multiple active badges
- Updated workflow and Python script

Closes MCP Project #3 improvements.